### PR TITLE
Fix for GHS

### DIFF
--- a/extra-services/gloomhaven-secretary/docker-compose.yml
+++ b/extra-services/gloomhaven-secretary/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '0.5'
+          cpus: '1'
           memory: 256M
     restart: unless-stopped
 

--- a/staticconfig/caddy/Caddyfile
+++ b/staticconfig/caddy/Caddyfile
@@ -108,8 +108,8 @@ ghs-server.{$DOMAIN} {
   @websockets {
     header Connection *Upgrade*
     header Upgrade websocket
-    header_down Access-Control-Allow-Origin *
-    transparent
+    header Access-Control-Allow-Origin ghs.{$DOMAIN}
+    header Access-Control-Allow-Origin gloomhaven-secretary.de
   }
   reverse_proxy @websockets gloomhaven-server:8080
 }


### PR DESCRIPTION
Removes an unsupported command for websockets. There are still problems with GHS connectivity, though.