### PR TITLE
Pinry and signifcant improvements to the Backup script

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -132,6 +132,9 @@ PIHOLE_DOMAIN=
 PIHOLE_TEMPUNIT=c #<c|k|f>
 PIHOLE_WEBTHEME=default-darker
 
+# Pinry
+PINRY_SECRETKEY=
+
 # Tandoor
 TANDOOR_DB_NAME=tandoor_db
 TANDOOR_DB_USER=djangouser

--- a/.env.template
+++ b/.env.template
@@ -60,6 +60,7 @@ PORT_PIHOLE_WEBSSL= # usually 443
 PORT_PIHOLE_DHCP= # usually 67
 PORT_PIHOLE_TCP= # usually 53
 PORT_PIHOLE_UDP= # usually 53
+PORT_PINRY=
 PORT_PODGRAB=
 PORT_RIPPING= #for web access to ARM. Required for initial setup
 PORT_SOCKY_PROXY= 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Includes:
 | <img src="https://caddy-forum-uploads.s3.amazonaws.com/original/2X/3/3859a874d26640df74a3b951d8052a3c3e749eed.png" width="32" alt="Caddy" /> Caddy | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/jellyfin.png" width="32" alt="Jellyfin" /> Jellyfin | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/homepage.png" width="32" alt="Homepage" /> Homepage |
 | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/crowdsec.png" width="32" alt="CrowdSec" /> CrowdSec | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/jellyseerr.png" width="32" alt="Jellyseerr" /> Jellyseerr | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/tandoorrecipes.png" width="32" alt="Tandoor Recipes" /> Tandoor Recipes |
 | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/duckdns.png" width="32" alt="DuckDNS" /> DuckDNS | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/prowlarr.png" width="32" alt="Prowlaar" /> Prowlaar | <img src="https://github.com/Lurkars/gloomhavensecretariat/blob/main/src/assets/icons/icon-masked-72x72.png" width="32" alt="Gloomhaven Secretariat" />Gloomhaven Secretariat |
-| <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/dozzle.png" width="32" alt="Dozzle" /> Dozzle | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/sonarr.png" width="32" alt="Sonarr" /> Sonarr |  |
+| <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/dozzle.png" width="32" alt="Dozzle" /> Dozzle | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/sonarr.png" width="32" alt="Sonarr" /> Sonarr | Pinry |
 | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/scrutiny.png" width="32" alt="Scrutiny" /> Scrutiny | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/radarr.png" width="32" alt="Radarr" /> Radarr |  |
 | <img src="https://raw.githubusercontent.com/crazy-max/diun/master/.res/diun.png" width="32" alt="Diun" /> Diun | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/qbittorrent.png" width="32" alt="qBitTorrent" /> qBitTorrent |  |
 | Endlessh | <img src="https://github.com/walkxcode/Dashboard-Icons/blob/main/png/wireguard.png" width="32" alt="Wireguard" /> Wireguard |  |
@@ -53,6 +53,7 @@ Alternatively, customize `COMPOSE_PROFILES=` in the .env file for a more "static
 | `media-request` | jellyseerr, sonarr, radarr, prowlarr, wireguard,  qbittorrent, podgrab | Full stack for end user media requests and file transfer. Non-local access to Jellyseerr requires  `external` |
 | `recipes` | tandoor_recipes, postres | Home recipes. Non-local access to tandoor requires  `external` |
 | `gloomhaven` | gloomhaven-secretary, ghs-server | Board games! Non-local access to client and server requires  `external` |
+| `lifestyle` | Pinry | Tools for the family |
 | `ripping` | automatic-ripping machine | local-only, not required all the time |
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
     labels:
       - diun.enable=true
-      - homepage.group=Home
+      - homepage.group=Lifestyle
       - homepage.name=Tandoor
       - homepage.icon=tandoorrecipes
       - homepage.href=http://${SERVER_URL}:${PORT_TANDOOR}
@@ -566,6 +566,45 @@ services:
           cpus: '0.5'
           memory: 256M
     restart: unless-stopped
+
+####################
+# Lifestyle
+####################
+
+  pinry:
+    container_name: pinry
+    image: getpinry/pinry
+    profiles:
+      - lifestyle
+
+    networks:
+      - caddy-net
+
+    ports:
+      - ${PORT_PINRY}:80
+
+    environment:
+      - ALLOW_NEW_REGISTRATIONS=True
+      - SECRET_KEY=${PINRY_SECRETKEY}
+    
+    labels:
+      - diun.enable=true
+      - homepage.group=Lifestyle
+      - homepage.name=Pinry
+      - homepage.icon=/icons/pinry.png
+      - homepage.href=http://${SERVER_URL}:${PORT_GHS_SERVER}
+      - homepage.description=Save, tag, and share images, videos and webpages
+
+    volumes:
+      - ${CONFIGDIR}/pinry:/data
+    
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+    restart: unless-stopped
+
 
 ####################
 # Network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -592,7 +592,7 @@ services:
       - homepage.group=Lifestyle
       - homepage.name=Pinry
       - homepage.icon=/icons/pinry.png
-      - homepage.href=http://${SERVER_URL}:${PORT_GHS_SERVER}
+      - homepage.href=http://${SERVER_URL}:${PORT_PINRY}
       - homepage.description=Save, tag, and share images, videos and webpages
 
     volumes:

--- a/dockerfiles/caddy.dockerfile
+++ b/dockerfiles/caddy.dockerfile
@@ -4,7 +4,7 @@ RUN xcaddy build \
     --with github.com/caddy-dns/duckdns \
     --with github.com/hslatman/caddy-crowdsec-bouncer/http
 
-FROM caddy:2.6.1
+FROM caddy:2.6.4
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -46,6 +46,10 @@ mkdir -p $varBackupDir/$varDate/qbittorrent
 cp -rpi $varConfigDir/qbt/qBittorrent/qBittorrent.conf $varBackupDir/$varDate/qbittorrent
 
 mkdir -p $varBackupDir/$varDate/pihole && cp -rpi $varConfigDir/pihole $varBackupDir/$varDate
+# the below databases are very large and can be rebuilt
+rm $varBackupDir/$varDate/pihole/pihole/gravity.db
+rm $varBackupDir/$varDate/pihole/pihole/gravity_old.db
+rm $varBackupDir/$varDate/pihole/pihole/pihole-FTL.db
 
 mkdir -p $varBackupDir/$varDate/pinry
 cp -rpi $varConfigDir/pinry/*.* $varBackupDir/$varDate/pinry
@@ -53,13 +57,13 @@ cp -rpi $varConfigDir/pinry/*.* $varBackupDir/$varDate/pinry
 mkdir -p $varBackupDir/$varDate/podgrab
 cp -rpi $varConfigDir/podgrab/podgrab.db $varBackupDir/$varDate/podgrab
 varTempPodgrabBackup=$(ls -Art $varConfigDir/podgrab/backups | tail -n 1)
-cp -rpi $varConfigDir/podgrab/backups $varBackupDir/$varDate/podgrab
+cp -rpi $varConfigDir/podgrab/backups/$varTempPodgrabBackup $varBackupDir/$varDate/podgrab/backups
 
-mkdir -p $varBackupDir/$varDate/ripping && cp -rpi $varConfigDir/ripping $varBackupDir/$varDate/ripping
+mkdir -p $varBackupDir/$varDate/ripping && cp -rpi $varConfigDir/ripping $varBackupDir/$varDate
 
-mkdir -p $varBackupDir/$varDate/scrutiny && cp -rpi $varConfigDir/scrutiny $varBackupDir/$varDate/scrutiny
+mkdir -p $varBackupDir/$varDate/scrutiny && cp -rpi $varConfigDir/scrutiny $varBackupDir/$varDate
 
-mkdir -p $varBackupDir/$varDate/unbound && cp -rpi $varConfigDir/unbound $varBackupDir/$varDate/unbound
+mkdir -p $varBackupDir/$varDate/unbound && cp -rpi $varConfigDir/unbound $varBackupDir/$varDate
 
 mkdir -p $varBackupDir/$varDate/uptime-kuma
 cp -rpi $varConfigDir/uptime-kuma/kuma.db $varBackupDir/$varDate/uptime-kuma
@@ -93,5 +97,5 @@ echo Backing Up Pinry Media
 mkdir -p $varBackupDir/$varDate-pinry
 cp -rpi $varConfigDir/pinry/static/media $varBackupDir/$varDate-pinry
 echo Creating Pinry Media Zip...
-cd $varBackupDir/$varDate-pinry
+cd $varBackupDir
 zip -r -9 $varDate-pinry $varDate-pinry > /dev/null 2>&1

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -15,7 +15,7 @@ sudo docker exec -t tandoor_db pg_dumpall -U tandoor_user > tandoor_pgdump.sql
 # Docker config backups
 echo Backing up Docker Configs...
 
-mkdir -p $varBackupDir/$varDate/ghs && cp -rpi $varConfigDir/ghs $varBackupDir/$varDate/ghs
+mkdir -p $varBackupDir/$varDate/ghs && cp -rpi $varConfigDir/ghs $varBackupDir/$varDate
 
 mkdir -p $varBackupDir/$varDate/homepage && cp -rpi $varConfigDir/homepage/*.yaml $varBackupDir/$varDate/homepage
 
@@ -28,6 +28,8 @@ mkdir -p $varBackupDir/$varDate/jellyseerr
 cp -rpi $varConfigDir/jellyseerr/db $varBackupDir/$varDate/jellyseerr
 cp -rpi $varConfigDir/jellyseerr/settings.json $varBackupDir/$varDate/jellyseerr
 
+
+# the *arr containers smartly have scheduled backups. So we pull only the most recent to save disk space
 mkdir -p $varBackupDir/$varDate/prowlarr
 varTempProwlarrBackup=$(ls -Art $varConfigDir/prowlarr/Backups/scheduled | tail -n 1)
 cp -rpi $varConfigDir/prowlarr/Backups/scheduled/$varTempProwlarrBackup $varBackupDir/$varDate/prowlarr
@@ -43,26 +45,29 @@ cp -rpi $varConfigDir/sonarr/Backups/scheduled/$varTempSonarrBackup $varBackupDi
 mkdir -p $varBackupDir/$varDate/qbittorrent
 cp -rpi $varConfigDir/qbt/qBittorrent/qBittorrent.conf $varBackupDir/$varDate/qbittorrent
 
-mkdir -p $varBackupDir/$varDate/pihole
-cp -rpi $varConfigDir/pihole $varBackupDir/$varDate/pihole
+mkdir -p $varBackupDir/$varDate/pihole && cp -rpi $varConfigDir/pihole $varBackupDir/$varDate
+
+mkdir -p $varBackupDir/$varDate/pinry
+cp -rpi $varConfigDir/pinry/*.* $varBackupDir/$varDate/pinry
 
 mkdir -p $varBackupDir/$varDate/podgrab
-cp -rpi $varConfigDir/podgrab $varBackupDir/$varDate/podgrab
+cp -rpi $varConfigDir/podgrab/podgrab.db $varBackupDir/$varDate/podgrab
+varTempPodgrabBackup=$(ls -Art $varConfigDir/podgrab/backups | tail -n 1)
+cp -rpi $varConfigDir/podgrab/backups $varBackupDir/$varDate/podgrab
 
-mkdir -p $varBackupDir/$varDate/ripping
-cp -rpi $varConfigDir/ripping $varBackupDir/$varDate/ripping
+mkdir -p $varBackupDir/$varDate/ripping && cp -rpi $varConfigDir/ripping $varBackupDir/$varDate/ripping
 
-mkdir -p $varBackupDir/$varDate/scrutiny
-cp -rpi $varConfigDir/scrutiny $varBackupDir/$varDate/scrutiny
+mkdir -p $varBackupDir/$varDate/scrutiny && cp -rpi $varConfigDir/scrutiny $varBackupDir/$varDate/scrutiny
 
-mkdir -p $varBackupDir/$varDate/unbound
-cp -rpi $varConfigDir/unbound $varBackupDir/$varDate/unbound
+mkdir -p $varBackupDir/$varDate/unbound && cp -rpi $varConfigDir/unbound $varBackupDir/$varDate/unbound
 
 mkdir -p $varBackupDir/$varDate/uptime-kuma
 cp -rpi $varConfigDir/uptime-kuma/kuma.db $varBackupDir/$varDate/uptime-kuma
 
 mkdir -p $varBackupDir/$varDate/wireguard
 cp -rpi $varConfigDir/wireguard/wg0.conf $varBackupDir/$varDate/wireguard
+
+
 
 # Environment Files
 echo Backing up .env...
@@ -77,6 +82,16 @@ cp -rpi /opt/snapraid-runner/snapraid-runner.conf $varBackupDir/$varDate
 
 
 # Zip file
-echo Creating Zip...
+echo Creating Primary Zip...
 cd $varBackupDir
+du -h --max-depth=1 $varDate | sort -hr
 zip -r -9 $varDate $varDate > /dev/null 2>&1
+
+
+# Large File Storage Backups
+echo Backing Up Pinry Media
+mkdir -p $varBackupDir/$varDate-pinry
+cp -rpi $varConfigDir/pinry/static/media $varBackupDir/$varDate-pinry
+echo Creating Pinry Media Zip...
+cd $varBackupDir/$varDate-pinry
+zip -r -9 $varDate-pinry $varDate-pinry > /dev/null 2>&1

--- a/staticconfig/caddy/Caddyfile
+++ b/staticconfig/caddy/Caddyfile
@@ -140,6 +140,13 @@ request.{$DOMAIN} {
   reverse_proxy jellyseerr:5055
 }
 
+pin.{$DOMAIN} {
+  import headers
+  import main
+
+  reverse_proxy pinry:80
+}
+
 status.{$DOMAIN} {
   import headers
   import main


### PR DESCRIPTION
- Closes #74 via [Pinry](https://github.com/pinry/pinry)
- Significantly decreases the backup filesize by excluding Pihole's gravity databases
- **Caddy is bumped to 2.6.4** 
- The backup script now avoids double-nested folders

This PR showcases how awesome Caddy is (and the benefit of #47 Caddy Snippets). Exposing a container externally and securely is pretty much copy and paste.