### PR TITLE
Back Merge: Maintenance/general 2025 04 (#122)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,6 +7,7 @@ PGID=
 TZ=
 
 HOST_NAME=
+HOST_DOMAIN= # if you have custom, local dns records (eg. via pihole)
 SERVER_URL= #server's IP Address on your LAN. For local access.
 
 CONFIGDIR=/srv/docker-config

--- a/services/dashboard/docker-compose.yml
+++ b/services/dashboard/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       PGID: ${PGID}
       TZ: ${TZ}
       LOG_LEVEL: 'debug'
+      HOMEPAGE_ALLOWED_HOSTS: ${SERVER_URL}:${PORT_DASH_HTTP},${HOST_NAME}.${HOST_DOMAIN}:${PORT_DASH_HTTP}
 
     volumes:
       - ${CONFIGDIR}/homepage:/app/config # Make sure your local config directory exists
@@ -50,3 +51,4 @@ networks:
   socky_proxy-net:
     name: socky_proxy-net
     external: true
+    

--- a/services/events/docker-compose.yml
+++ b/services/events/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   rallly_db:
     container_name: rallly_db
-    image: postgres:15.4-alpine
+    image: postgres:17.4-alpine
 
     networks:
       - rallly-net

--- a/services/public/docker-compose.yml
+++ b/services/public/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       EMAIL: ${EMAIL_ADMIN}
       DUCKDNS_API_TOKEN: ${DUCKDNS_TOKEN}
       
-      BOUNCER_CADDY_TOKEN: ${BOUNCER_CADDY_TOKEN}
+      # BOUNCER_CADDY_TOKEN: ${BOUNCER_CADDY_TOKEN}
 
     labels:
       - diun.enable=true

--- a/services/recipes/docker-compose.yml
+++ b/services/recipes/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   tandoor:
     container_name: tandoor
-    image: vabene1111/recipes:latest
+    image: vabene1111/recipes:1.5.27 # pinned until #121
 
     depends_on:
       tandoor_db:


### PR DESCRIPTION
* Update for Homepage changes

Homepage now requires allowlisting the domains you can access its dashboard from

* Postgres -> 17.4

* Pin Tandoor 1.5.27

Waiting for a much larger upgrade via #121

* Comment out Crowdsec

Was causing warnings from docker

* Dashboard port variable